### PR TITLE
Added support for basic SSL/TLS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,62 @@ aliases each user to user@that.users.mailhost.
 - *Module Default*: '$myhostname'
 
 
+main_smtp_tls_mandatory_protocols
+---------------------------------
+List of SSL/TLS protocols that the Postfix SMTP client will use with mandatory TLS encryption.
+An empty value means allow all protocols. The valid protocol names, (see SSL_get_version(3)), are
+"SSLv2", "SSLv3" and "TLSv1". The default value is "!SSLv2, !SSLv3" for Postfix releases after
+the middle of 2015, "!SSLv2" for older releases.
+
+- *Module Default*: undef
+
+
+main_smtp_tls_protocols
+-----------------------
+List of TLS protocols that the Postfix SMTP client will exclude or include with opportunistic TLS
+encryption. The default value is "!SSLv2, !SSLv3" for Postfix releases after the middle of 2015,
+"!SSLv2" for older releases. Before Postfix 2.6, the Postfix SMTP client would use all protocols
+with opportunistic TLS.
+
+- *Module Default*: undef
+
+
+main_smtp_tls_security_level
+----------------------------
+The default SMTP TLS security level for the Postfix SMTP client. Specify one of the following
+security levels: none, may, encrypt, dane, dane-only, fingerprint, verify, secure.
+
+- *Module Default*: undef
+
+
+main_smtpd_tls_mandatory_protocols
+----------------------------------
+List of SSL/TLS protocols that the Postfix SMTP server will use with mandatory TLS encryption.
+An empty value means allow all protocols. The valid protocol names, are "SSLv2", "SSLv3" and
+"TLSv1". The default value is "!SSLv2, !SSLv3" for Postfix releases after the middle of 2015,
+"!SSLv2" for older releases.
+
+- *Module Default*: undef
+
+
+main_smtpd_tls_mandatory_protocols
+----------------------------------
+List of TLS protocols that the Postfix SMTP server will exclude or include with opportunistic TLS
+encryption. An empty value means allow all protocols. The valid protocol names, are "SSLv2",
+"SSLv3" and "TLSv1". The default value is "!SSLv2, !SSLv3" for Postfix releases after the middle
+of 2015, "!SSLv2" for older releases.
+
+- *Module Default*: undef
+
+
+main_smtpd_tls_security_level
+-----------------------------
+The SMTP TLS security level for the Postfix SMTP server. Specify one of the following security
+levels: none, may, encrypt.
+
+- *Module Default*: undef
+
+
 main_queue_directory (default: see "postconf -d" output)
 --------------------------------------------------------
 The location of the Postfix top-level queue directory. This is the root directory of Postfix daemon

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,41 +3,47 @@
 # Manage Postfix to relay mail
 
 class postfix (
-  $main_alias_database        = 'hash:/etc/aliases',
-  $main_alias_maps            = 'hash:/etc/aliases',
-  $main_append_dot_mydomain   = 'no',
-  $main_biff                  = 'no',
-  $main_command_directory     = 'USE_DEFAULTS',
-  $main_daemon_directory      = 'USE_DEFAULTS',
-  $main_data_directory        = 'USE_DEFAULTS',
-  $main_inet_interfaces       = '127.0.0.1',
-  $main_inet_protocols        = 'ipv4',
-  $main_mailbox_command       = undef,
-  $main_mailbox_size_limit    = 0,
-  $main_mydestination         = 'localhost',
-  $main_myhostname            = $::fqdn,
-  $main_mynetworks            = '127.0.0.0/8',
-  $main_myorigin              = '$myhostname',
-  $main_queue_directory       = 'USE_DEFAULTS',
-  $main_recipient_delimiter   = '+',
-  $main_relay_domains         = undef,
-  $main_relayhost             = "mailhost.${::domain}",
-  $main_relayhost_port        = '25',
-  $main_setgid_group          = 'USE_DEFAULTS',
-  $main_transport_maps        = 'hash:/etc/postfix/transport',
-  $main_virtual_alias_domains = undef,
-  $main_virtual_alias_maps    = 'hash:/etc/postfix/virtual',
-  $packages                   = 'USE_DEFAULTS',
-  $service_enable             = true,
-  $service_ensure             = 'running',
-  $service_hasrestart         = true,
-  $service_hasstatus          = true,
-  $service_name               = 'postfix',
-  $template_main_cf           = 'postfix/main.cf.erb',
-  $transport_maps             = undef,
-  $transport_maps_external    = false,
-  $virtual_aliases            = undef,
-  $virtual_aliases_external   = false,
+  $main_alias_database                = 'hash:/etc/aliases',
+  $main_alias_maps                    = 'hash:/etc/aliases',
+  $main_append_dot_mydomain           = 'no',
+  $main_biff                          = 'no',
+  $main_command_directory             = 'USE_DEFAULTS',
+  $main_daemon_directory              = 'USE_DEFAULTS',
+  $main_data_directory                = 'USE_DEFAULTS',
+  $main_inet_interfaces               = '127.0.0.1',
+  $main_inet_protocols                = 'ipv4',
+  $main_mailbox_command               = undef,
+  $main_mailbox_size_limit            = '0',
+  $main_mydestination                 = 'localhost',
+  $main_myhostname                    = $::fqdn,
+  $main_mynetworks                    = '127.0.0.0/8',
+  $main_myorigin                      = '$myhostname',
+  $main_queue_directory               = 'USE_DEFAULTS',
+  $main_recipient_delimiter           = '+',
+  $main_relay_domains                 = undef,
+  $main_relayhost                     = "mailhost.${::domain}",
+  $main_relayhost_port                = '25',
+  $main_setgid_group                  = 'USE_DEFAULTS',
+  $main_transport_maps                = 'hash:/etc/postfix/transport',
+  $main_virtual_alias_domains         = undef,
+  $main_virtual_alias_maps            = 'hash:/etc/postfix/virtual',
+  $main_smtp_tls_mandatory_protocols  = undef,
+  $main_smtp_tls_protocols            = undef,
+  $main_smtp_tls_security_level       = undef,
+  $main_smtpd_tls_mandatory_protocols = undef,
+  $main_smtpd_tls_protocols           = undef,
+  $main_smtpd_tls_security_level      = undef,
+  $packages                           = 'USE_DEFAULTS',
+  $service_enable                     = true,
+  $service_ensure                     = 'running',
+  $service_hasrestart                 = true,
+  $service_hasstatus                  = true,
+  $service_name                       = 'postfix',
+  $template_main_cf                   = 'postfix/main.cf.erb',
+  $transport_maps                     = undef,
+  $transport_maps_external            = false,
+  $virtual_aliases                    = undef,
+  $virtual_aliases_external           = false,
 ) {
 
   # <provide os default values>
@@ -228,6 +234,12 @@ class postfix (
   validate_bool($transport_maps_external_real)
   if $virtual_aliases_real { validate_hash($virtual_aliases_real) }
   validate_bool($virtual_aliases_external_real)
+  validate_string($main_smtp_tls_mandatory_protocols)
+  validate_string($main_smtp_tls_protocols)
+  validate_string($main_smtp_tls_security_level)
+  validate_string($main_smtpd_tls_mandatory_protocols)
+  validate_string($main_smtpd_tls_protocols)
+  validate_string($main_smtpd_tls_security_level)
   # </validating variables>
 
   # <Install & Config>

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -271,7 +271,7 @@ describe 'postfix' do
     let(:facts) { { :osfamily => 'Redhat' } }
 
     #<testing free string variables for main.cf>
-    ['alias_database','alias_maps','inet_interfaces','inet_protocols','mailbox_command','mydestination','mynetworks','myorigin','relay_domains','setgid_group','transport_maps','virtual_alias_maps','virtual_alias_domains',].each do |variable|
+    ['alias_database','alias_maps','inet_interfaces','inet_protocols','mailbox_command','mydestination','mynetworks','myorigin','relay_domains','setgid_group','transport_maps','virtual_alias_maps','virtual_alias_domains','smtp_tls_mandatory_protocols','smtp_tls_protocols','smtp_tls_security_level','smtpd_tls_mandatory_protocols','smtpd_tls_protocols','smtpd_tls_security_level'].each do |variable|
       ['string1','string2',].each do |value|
         context "where main_#{variable} is set to valid #{value} (as #{value.class})" do
           let(:params) { {

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -26,6 +26,30 @@ inet_interfaces = <%= @main_inet_interfaces_real %>
 # inet_protocols = ipv4 (RHEL & Suse)
 # inet_protocols = all (Debian & Ubuntu)
 inet_protocols = <%= @main_inet_protocols_real %>
+<% if @main_smtp_tls_mandatory_protocols -%>
+
+smtp_tls_mandatory_protocols = <%= @main_smtp_tls_mandatory_protocols %>
+<% end -%>
+<% if @main_smtp_tls_protocols -%>
+
+smtp_tls_protocols = <%= @main_smtp_tls_protocols %>
+<% end -%>
+<% if @main_smtp_tls_security_level -%>
+
+smtp_tls_security_level = <%= @main_smtp_tls_security_level %>
+<% end -%>
+<% if @main_smtpd_tls_mandatory_protocols -%>
+
+smtpd_tls_mandatory_protocols = <%= @main_smtpd_tls_mandatory_protocols %>
+<% end -%>
+<% if @main_smtpd_tls_protocols -%>
+
+smtpd_tls_protocols = <%= @main_smtpd_tls_protocols %>
+<% end -%>
+<% if @main_smtpd_tls_security_level -%>
+
+smtpd_tls_security_level = <%= @main_smtpd_tls_security_level %>
+<% end -%>
 <% if @main_mailbox_command -%>
 
 mailbox_command = <%= @main_mailbox_command %>


### PR DESCRIPTION
The following parameters has been added as input parameters:
- main_smtp_tls_mandatory_protocols
- main_smtp_tls_protocols
- main_smtp_tls_security_level
- main_smtpd_tls_mandatory_protocols
- main_smtpd_tls_protocols
- main_smtpd_tls_security_level
