### PR TITLE
Define $os_defaults_missing in all cases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,11 @@ gem 'puppet-lint', '>= 1.0', '< 3.0' # change to '~> 2.0' once the plugins got u
 gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet'
 
+if RUBY_VERSION < '2.0'
+  # json 2.x requires ruby 2.0. Lock to 1.8
+  gem 'json', '~> 1.8'
+end
+
 # rspec must be v2 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
   gem 'rspec', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 
 gem 'metadata-json-lint'
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
-gem 'puppet-lint', '>= 1.0.0'
+gem 'puppet-lint', '>= 1.0', '< 3.0' # change to '~> 2.0' once the plugins got updated
 gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet'
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
 PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Run puppet in noop mode and check for syntax errors."

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,7 @@ class postfix (
       $main_recipient_delimiter_default = ''
       $main_setgid_group_default        = 'postdrop'
       $packages_default                 = 'postfix'
+      $os_defaults_missing              = false
     }
     'RedHat': {
       $main_command_directory_default   = '/usr/sbin'
@@ -72,6 +73,7 @@ class postfix (
       $main_recipient_delimiter_default = ''
       $main_setgid_group_default        = 'postdrop'
       $packages_default                 = 'postfix'
+      $os_defaults_missing              = false
     }
     'Suse': {
       $main_command_directory_default   = '/usr/sbin'
@@ -83,6 +85,7 @@ class postfix (
       $main_recipient_delimiter_default = ''
       $main_setgid_group_default        = 'maildrop'
       $packages_default                 = 'postfix'
+      $os_defaults_missing              = false
     }
     default: {
       $os_defaults_missing = true


### PR DESCRIPTION
This suppresses the warning message:
Puppet Unknown variable: 'os_defaults_missing'. at postfix/manifests/init.pp:95:6
