### PR TITLE
Add parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,61 @@ security levels: none, may, encrypt, dane, dane-only, fingerprint, verify, secur
 - *Module Default*: undef
 
 
+main_smtpd_helo_required (default: no)
+--------------------------------------
+Require that a remote SMTP client introduces itself with the HELO or EHLO
+command before sending the MAIL command or other commands that require EHLO
+negotiation.
+
+- *Module Default*: undef
+
+
+main_smtpd_helo_restrictions (default: empty)
+---------------------------------------------
+Optional restrictions that the Postfix SMTP server applies in the context of a
+client HELO command. See SMTPD_ACCESS_README, section "Delayed evaluation of
+SMTP access restriction lists" for a discussion of evaluation context and time.
+
+The default is to permit everything.
+
+Note: specify  "smtpd_helo_required = yes" to fully enforce this restriction
+(without "smtpd_helo_required = yes", a client can simply skip
+smtpd_helo_restrictions by not sending HELO or EHLO).
+
+- *Module Default*: undef
+
+<pre>
+postfix::main_smtpd_helo_restrictions:
+    - 'permit_mynetworks'
+    - 'reject_invalid_helo_hostname'
+    - 'reject_unknown_helo_hostname'
+</pre>
+
+
+main_smtpd_recipient_restrictions (default: see postconf -d output)
+-------------------------------------------------------------------
+Optional restrictions that the Postfix SMTP server applies in the context of a
+client RCPT TO command, after smtpd_relay_restrictions. See SMTPD_ACCESS_README,
+section "Delayed evaluation of SMTP access restriction lists" for a discussion
+of evaluation context and time. With Postfix versions before 2.10, the rules
+for relay permission and spam blocking were combined under
+smtpd_recipient_restrictions, resulting in error-prone configuration.
+As of Postfix 2.10, relay permission rules are preferably implemented with
+smtpd_relay_restrictions, so that a permissive spam blocking policy under
+smtpd_recipient_restrictions will no longer result in a permissive mail relay
+policy.
+
+Read more in man pages.
+
+- *Module Default*: undef
+
+<pre>
+postfix::main_smtpd_recipient_restrictions:
+    - 'permit_mynetworks'
+    - 'permit_sasl_authenticated'
+</pre>
+
+
 main_smtpd_tls_mandatory_protocols
 ----------------------------------
 List of SSL/TLS protocols that the Postfix SMTP server will use with mandatory TLS encryption.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,16 @@ Note: This limit must not be smaller than the message size limit.
 - *Module Default*: 0
 
 
+main_mydomain (default: see "postconf -d" output)
+-------------------------------------------------
+The internet hostname of this mail system. The default is to use the
+fully-qualified domain name (FQDN) from gethostname(), or to use the non-FQDN
+result from gethostname() and append ".$mydomain". $myhostname is used
+as a default value for many other configuration parameters.
+
+- *Module default*: undef
+
+
 main_mydestination (default: $myhostname, localhost.$mydomain, localhost)
 -------------------------------------------------------------------------
 The list of domains that are delivered via the $local_transport mail delivery transport.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class postfix (
   $main_mailbox_command               = undef,
   $main_mailbox_size_limit            = '0',
   $main_mydestination                 = 'localhost',
+  $main_mydomain                      = undef,
   $main_myhostname                    = $::fqdn,
   $main_mynetworks                    = '127.0.0.0/8',
   $main_myorigin                      = '$myhostname',
@@ -209,6 +210,7 @@ class postfix (
   if is_integer($main_mailbox_size_limit_real) == false { fail("main_mailbox_size_limit must be an integer and is set to <${main_mailbox_size_limit_real}>") }
   if $main_mailbox_size_limit_real + 0 < 0 { fail("main_mailbox_size_limit needs a minimum value of 0 and is set to <${main_mailbox_size_limit_real}>") }
   validate_string($main_mydestination_real)
+  if $main_mydomain != undef and is_domain_name($main_mydomain) == false { fail("main_mydomain must be a domain name and is set to <${main_mydomain}>") }
   if is_domain_name($main_myhostname_real) == false { fail("main_myhostname must be a domain name and is set to <${main_myhostname_real}>") }
   if empty($main_mynetworks_real) == true { fail("main_mynetworks must contain a valid value and is set to <${main_mynetworks_real}>") }
   validate_string($main_mynetworks_real)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,9 @@ class postfix (
   $main_smtp_tls_mandatory_protocols  = undef,
   $main_smtp_tls_protocols            = undef,
   $main_smtp_tls_security_level       = undef,
+  $main_smtpd_helo_required           = undef,
+  $main_smtpd_helo_restrictions       = undef,
+  $main_smtpd_recipient_restrictions  = undef,
   $main_smtpd_tls_mandatory_protocols = undef,
   $main_smtpd_tls_protocols           = undef,
   $main_smtpd_tls_security_level      = undef,
@@ -256,6 +259,9 @@ class postfix (
   validate_string($main_smtpd_tls_security_level)
   if $main_smtpd_tls_key_file != undef { validate_absolute_path($main_smtpd_tls_key_file) }
   if $main_smtpd_tls_cert_file != undef { validate_absolute_path($main_smtpd_tls_cert_file) }
+  if $main_smtpd_helo_required != undef { validate_re($main_smtpd_helo_required, '^(yes|no)$', "main_smtpd_helo_required may be either 'yes' or 'no' and is set to <${main_smtpd_helo_required}>") }
+  if $main_smtpd_helo_restrictions != undef { validate_array($main_smtpd_helo_restrictions) }
+  if $main_smtpd_recipient_restrictions != undef { validate_array($main_smtpd_recipient_restrictions) }
   # </validating variables>
 
   # <Install & Config>

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -107,6 +107,7 @@ describe 'postfix' do
         it { should contain_file('postfix_main.cf').with_content(/^setgid_group = #{v[:main_setgid_group_default]}$/) }
         it { should contain_file('postfix_main.cf').without_content(/^virtual_alias_maps = hash:\/etc\/postfix\/virtual$/) }
         it { should contain_file('postfix_main.cf').without_content(/^mailbox_command =/) }
+        it { should contain_file('postfix_main.cf').without_content(/^mydomain =/) }
         it { should contain_file('postfix_main.cf').without_content(/^relay_domains =/) }
         it { should contain_file('postfix_main.cf').without_content(/^transport_maps/) }
 
@@ -214,6 +215,7 @@ describe 'postfix' do
     it { should contain_file('postfix_main.cf').with_content(/^setgid_group = uOSuser$/) }
     it { should contain_file('postfix_main.cf').without_content(/^virtual_alias_maps = hash:\/etc\/postfix\/virtual$/) }
     it { should contain_file('postfix_main.cf').without_content(/^mailbox_command =/) }
+    it { should contain_file('postfix_main.cf').without_content(/^mydomain =/) }
     it { should contain_file('postfix_main.cf').without_content(/^relay_domains =/) }
     it { should contain_file('postfix_main.cf').without_content(/^transport_maps/) }
     it { should contain_file('postfix_main.cf').without_content(/^smtp_tls_mandatory_protocols/) }
@@ -584,7 +586,7 @@ describe 'postfix' do
         :message => 'str2bool',
       },
       'domain_name' => {
-        :name    => ['main_myhostname','main_relayhost'],
+        :name    => ['main_mydomain','main_myhostname','main_relayhost'],
         :valid   => ['v.al.id','val.id'],
         :invalid => ['in,val.id','in_val.id',2.42,['array'],a={'ha'=>'sh'}],
         :message => 'must be a domain name and is set to',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -109,6 +109,9 @@ describe 'postfix' do
         it { should contain_file('postfix_main.cf').without_content(/^mailbox_command =/) }
         it { should contain_file('postfix_main.cf').without_content(/^mydomain =/) }
         it { should contain_file('postfix_main.cf').without_content(/^relay_domains =/) }
+        it { should contain_file('postfix_main.cf').without_content(/^smtpd_helo_required/) }
+        it { should contain_file('postfix_main.cf').without_content(/^smtpd_helo_restrictions/) }
+        it { should contain_file('postfix_main.cf').without_content(/^smtpd_recipient_restrictions/) }
         it { should contain_file('postfix_main.cf').without_content(/^transport_maps/) }
 
 
@@ -221,6 +224,9 @@ describe 'postfix' do
     it { should contain_file('postfix_main.cf').without_content(/^smtp_tls_mandatory_protocols/) }
     it { should contain_file('postfix_main.cf').without_content(/^smtp_tls_protocols/) }
     it { should contain_file('postfix_main.cf').without_content(/^smtp_tls_security_level/) }
+    it { should contain_file('postfix_main.cf').without_content(/^smtpd_helo_required/) }
+    it { should contain_file('postfix_main.cf').without_content(/^smtpd_helo_restrictions/) }
+    it { should contain_file('postfix_main.cf').without_content(/^smtpd_recipient_restrictions/) }
     it { should contain_file('postfix_main.cf').without_content(/^smtpd_tls_mandatory_protocols/) }
     it { should contain_file('postfix_main.cf').without_content(/^smtpd_tls_protocols/) }
     it { should contain_file('postfix_main.cf').without_content(/^smtpd_tls_security_level/) }
@@ -391,6 +397,60 @@ describe 'postfix' do
           'before' => 'Package[sendmail]',
         })
       }
+    end
+
+    context "with main_smtpd_helo_required set to 'yes'" do
+      let(:params) {
+        {
+          'main_smtpd_helo_required' => 'yes',
+        }
+      }
+
+      it { should contain_file('postfix_main.cf').with_content(/^smtpd_helo_required = yes/) }
+    end
+
+    describe "with main_smtpd_restrictions" do
+      context "set to [ 'permit_mynetworks' ]" do
+        let(:params) {
+          {
+            'main_smtpd_helo_restrictions'  => [ 'permit_mynetworks'],
+          }
+        }
+
+        it { should contain_file('postfix_main.cf').with_content(/^smtpd_helo_restrictions = permit_mynetworks$/) }
+      end
+
+      context "set to [ 'permit_mynetworks', 'reject_invalid_helo_hostname' ]" do
+        let(:params) {
+          {
+            'main_smtpd_helo_restrictions'  => [ 'permit_mynetworks', 'reject_invalid_helo_hostname'],
+          }
+        }
+
+        it { should contain_file('postfix_main.cf').with_content(/^smtpd_helo_restrictions = permit_mynetworks,\n    reject_invalid_helo_hostname/) }
+      end
+    end
+
+    describe 'with main_smtpd_recipient_restrictions' do
+      context "set to [ 'permit_mynetworks' ]" do
+        let(:params) {
+          {
+            'main_smtpd_recipient_restrictions' => [ 'permit_mynetworks'],
+          }
+        }
+
+        it { should contain_file('postfix_main.cf').with_content(/^smtpd_recipient_restrictions = permit_mynetworks$/) }
+      end
+
+      context "set to [ 'permit_mynetworks', 'permit_sasl_authenticated' ]" do
+        let(:params) {
+          {
+            'main_smtpd_recipient_restrictions' => [ 'permit_mynetworks', 'permit_sasl_authenticated'],
+          }
+        }
+
+        it { should contain_file('postfix_main.cf').with_content(/^smtpd_recipient_restrictions = permit_mynetworks,\n    permit_sasl_authenticated/) }
+      end
     end
 
     context "with packages set to <['postfix','postfix-helper']>" do
@@ -579,6 +639,12 @@ describe 'postfix' do
         :invalid => ['invalid',3,2.42,['array'],a={'ha'=>'sh'}],
         :message => 'is not an absolute path',
       },
+      'array' => {
+        :name    => ['main_smtpd_helo_restrictions', 'main_smtpd_recipient_restrictions'],
+        :valid   => [['array'], ['array', 'array']],
+        :invalid => ['invalid', 3,2.42,a={'ha'=>'sh'}, true, false],
+        :message => 'is not an Array',
+      },
       'bool_stringified' => {
         :name    => ['service_hasrestart','service_hasstatus','transport_maps_external','virtual_aliases_external'],
         :valid   => [true,'true',false,'false'],
@@ -629,7 +695,7 @@ describe 'postfix' do
         :message => 'may be either \'true\', \'false\' or \'manual\'',
       },
       'regex_yes/no' => {
-        :name    => ['main_append_dot_mydomain','main_biff'],
+        :name    => ['main_append_dot_mydomain','main_biff', 'main_smtpd_helo_required'],
         :valid   => ['yes','no'],
         :invalid => [true,false,'invalid',3,2.42,['array'],a={'ha'=>'sh'}],
         :message => 'may be either \'yes\' or \'no\'',

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -68,6 +68,10 @@ mailbox_size_limit = <%= @main_mailbox_size_limit_real %>
 
 # mydestination = $myhostname, localhost.$mydomain, localhost
 mydestination = <%= @main_mydestination_real %>
+<% if @main_mydomain -%>
+
+mydomain = <%= @main_mydomain %>
+<% end -%>
 
 # myhostname = <%= @hostname %>.localdomain (Debian, Suse & Ubuntu)
 # myhostname = <%= @fqdn %> (RHEL)

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -38,6 +38,18 @@ smtp_tls_protocols = <%= @main_smtp_tls_protocols %>
 
 smtp_tls_security_level = <%= @main_smtp_tls_security_level %>
 <% end -%>
+<% if @main_smtpd_helo_required -%>
+
+smtpd_helo_required = <%= @main_smtpd_helo_required %>
+<% end -%>
+<% if @main_smtpd_helo_restrictions -%>
+
+smtpd_helo_restrictions = <%= @main_smtpd_helo_restrictions.join(",\n    ") %>
+<% end -%>
+<% if @main_smtpd_recipient_restrictions -%>
+
+smtpd_recipient_restrictions = <%= @main_smtpd_recipient_restrictions.join(",\n    ") %>
+<% end -%>
 <% if @main_smtpd_tls_mandatory_protocols -%>
 
 smtpd_tls_mandatory_protocols = <%= @main_smtpd_tls_mandatory_protocols %>


### PR DESCRIPTION
This pull request adds a total of four new parameters to configure my_domain, smtpd_helo_required, smtpd_helo_restrictions and finally smtpd_recipient_restrictions.

With the default settings no additional entries are added to main.cf.
