### PR TITLE
Add acceptance tests for Debian 10/11

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -6,6 +6,8 @@ default:
     - 'litmusimage/centos:7'
     - 'litmusimage/centos:stream8'
     - 'litmusimage/centos:stream9'
+    - 'litmusimage/debian:10'
+    - 'litmusimage/debian:11'
     - 'litmusimage/oraclelinux:6'
     - 'litmusimage/oraclelinux:7'
     - 'litmusimage/scientificlinux:6'


### PR DESCRIPTION
Wasn't able to get acceptance tests running on Debian 8/9 images provided by Puppet Litmus. But Debian 10/11 do work out of the box. Guess they don't hurt and hopefully support for Debian 10/11 will be added soon ;)
