### PR TITLE
Add canonical maps (v1)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   repositories:
     stdlib:
-      repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+      repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
       ref:  '4.6.0'
   symlinks:
     postfix: "#{source_dir}"

--- a/templates/canonical.erb
+++ b/templates/canonical.erb
@@ -1,0 +1,8 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+<% if @canonical_maps_real -%>
+<%   @canonical_maps_real.sort.each do |key, value| -%>
+<%= key %>		<%= value %>
+<%   end -%>
+<% end -%>

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -119,6 +119,10 @@ virtual_alias_domains = <%= @main_virtual_alias_domains_real %>
 
 virtual_alias_maps = <%= @main_virtual_alias_maps_real %>
 <% end -%>
+<% if @main_canonical_maps_real and (@canonical_maps_real or @canonical_maps_external_real) -%>
+
+canonical_maps = <%= @main_canonical_maps_real -%>
+<% end -%>
 <% if @main_transport_maps_real and (@transport_maps_real or @transport_maps_external_real) -%>
 
 transport_maps = <%= @main_transport_maps_real %>


### PR DESCRIPTION
Adds support for canonical_maps in v1 branch. Added since we require this functionality on this old version. Didn't really want to do  this though.

Spec tests works locally!